### PR TITLE
Fix Bug JAH-1965

### DIFF
--- a/docs/monasca-api-spec.md
+++ b/docs/monasca-api-spec.md
@@ -1340,7 +1340,7 @@ None.
 
 #### Request Body
 * name (string(250), required) - A descriptive name of the notification method.
-* type (string(100), required) - The type of notification method (`EMAIL`, `WEBHOOK`, or `PAGERDUTY` ).
+* type (string, required) - The type of notification method (`EMAIL`, `WEBHOOK`, or `PAGERDUTY` ).
 * address (string(100), required) - The email/url address to notify.
 
 #### Request Examples
@@ -1546,7 +1546,7 @@ None.
 
 #### Request Body
 * name (string(250), required) - A descriptive name of the notifcation method.
-* type (string(100), required) - The type of notification method (`EMAIL`, `WEBHOOK`, or `PAGERDUTY` ).
+* type (string, required) - The type of notification method (`EMAIL`, `WEBHOOK`, or `PAGERDUTY` ).
 * address (string(100), required) - The email/url address to notify.
 
 #### Request Examples


### PR DESCRIPTION
Fixes bug JAH-1965 - Monasca-api Documentation: Length of notification type (string(100)), is irrelavent as the type can only be one of (EMAIL, WEBHOOK, or PAGERDUTY ).